### PR TITLE
Fix #1 redirect loop on Special:FollowList

### DIFF
--- a/includes/SpecialFollowlist.php
+++ b/includes/SpecialFollowlist.php
@@ -28,7 +28,7 @@
  * @ingroup SpecialPage
  */
 class SpecialFollowlist extends ChangesListSpecialPage {
-	public function __construct( $page = 'Followlist', $restriction = 'viewmywatchlist' ) {
+	public function __construct( $page = 'FollowList', $restriction = 'viewmywatchlist' ) {
 		parent::__construct( $page, $restriction );
 	}
 


### PR DESCRIPTION
The `SpecialPage` constructor must be called with the same name configured in `$wgSpecialPages`.