### PR TITLE
Fix Strict Standards warnings

### DIFF
--- a/includes/SpecialEditFollowList.php
+++ b/includes/SpecialEditFollowList.php
@@ -134,9 +134,10 @@ class SpecialEditFollowList extends UnlistedSpecialPage {
 	 *
 	 * @param string $search Prefix to search for
 	 * @param int $limit Maximum number of results to return
+	 * @param int $offset Number of results to skip
 	 * @return string[] Matching subpages
 	 */
-	public function prefixSearchSubpages( $search, $limit = 10 ) {
+	public function prefixSearchSubpages( $search, $limit, $offset ) {
 		return self::prefixSearchArray(
 			$search,
 			$limit,
@@ -145,7 +146,8 @@ class SpecialEditFollowList extends UnlistedSpecialPage {
 			array(
 				'clear',
 				'raw',
-			)
+			),
+			$offset
 		);
 	}
 

--- a/includes/SpecialFollowlist.php
+++ b/includes/SpecialFollowlist.php
@@ -83,9 +83,10 @@ class SpecialFollowlist extends ChangesListSpecialPage {
 	 *
 	 * @param string $search Prefix to search for
 	 * @param int $limit Maximum number of results to return
+	 * @param int $offset Number of results to skip
 	 * @return string[] Matching subpages
 	 */
-	public function prefixSearchSubpages( $search, $limit = 10 ) {
+	public function prefixSearchSubpages( $search, $limit, $offset ) {
 		// See also SpecialEditWatchlist::prefixSearchSubpages
 		return self::prefixSearchArray(
 			$search,
@@ -94,7 +95,8 @@ class SpecialFollowlist extends ChangesListSpecialPage {
 				'clear',
 				'edit',
 				'raw',
-			)
+			),
+			$offset
 		);
 	}
 


### PR DESCRIPTION
* Declaration of `SpecialFollowlist::prefixSearchSubpages()` should be compatible with `SpecialPage::prefixSearchSubpages($search, $limit, $offset)`

* Declaration of `SpecialEditFollowList::prefixSearchSubpages()` should be compatible with `SpecialPage::prefixSearchSubpages($search, $limit, $offset)`